### PR TITLE
Fixing Copy / Pasta issues

### DIFF
--- a/hello-minicli/README.md
+++ b/hello-minicli/README.md
@@ -37,7 +37,7 @@ This will generate a `melange.rsa` and `melange.rsa.pub` files in the current di
 Next, build the APK defined in the `melange.yaml` file:
 
 ```shell
-docker run --privileged --rm -v "${PWD}":/work \
+docker run --privileged --rm --volume "${PWD}":/work \
 cgr.dev/chainguard/melange build melange.yaml \
 --arch amd64,aarch64 \
 --signing-key melange.rsa

--- a/hello-minicli/README.md
+++ b/hello-minicli/README.md
@@ -66,8 +66,8 @@ With the APK packages and APK index in place, you can now build a container imag
 
 ```shell
 docker run --rm --workdir /work -v ${PWD}:/work cgr.dev/chainguard/apko \
-  build apko.yaml hello-minicli:test hello-minicli.tar \
-  --arch host
+build apko.yaml hello-minicli:test hello-minicli.tar \
+--arch host
 ```
 
 This will build an OCI image based on your host system's architecture - most likely this will be `x86_64`.

--- a/hello-minicli/README.md
+++ b/hello-minicli/README.md
@@ -37,11 +37,10 @@ This will generate a `melange.rsa` and `melange.rsa.pub` files in the current di
 Next, build the APK defined in the `melange.yaml` file:
 
 ```shell
-docker run --privileged --rm -v "${PWD}":/work \                         
-  cgr.dev/chainguard/melange build melange.yaml \
-  --arch amd64,aarch64 \
-  --signing-key melange.rsa
-
+docker run --privileged --rm -v "${PWD}":/work \
+cgr.dev/chainguard/melange build melange.yaml \
+--arch amd64,aarch64 \
+--signing-key melange.rsa
 ```
 
 This should get you `aarch64` and `x86_64` APK packages at the location `./packages`:


### PR DESCRIPTION
When copying the excess spaces results in the following error:
![image](https://github.com/user-attachments/assets/fe489050-fceb-41fd-8d09-19be43efe071)

The two spaces at the start of the shell line results in extra spaces in the command / in history. 